### PR TITLE
Feat Display author name from database

### DIFF
--- a/lib/components/post_list_component.dart
+++ b/lib/components/post_list_component.dart
@@ -2,52 +2,61 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:urbanlink_project/models/posts.dart';
 import 'package:urbanlink_project/pages/postpage/postedpage.dart';
+import 'package:urbanlink_project/repositories/user_database_service.dart';
 import 'package:urbanlink_project/services/auth.dart';
 
 class PostListComponent {
-  static Widget buildPost(Post post) {
-    return ListTile(
-      title: Text(
-        post.postTitle,
-        style: const TextStyle(
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      subtitle: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        Text(
-          post.postContent,
-          maxLines: 1,
-          overflow: TextOverflow.fade,
-        ),
-        Row(
-          children: [
-            Text(
-              post.authorName,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
+  Widget _buildPost(Post post) {
+    return FutureBuilder<String>(
+      future: UserDatabaseService.getUsernameById(post.postAuthorId),
+      builder: (context, snapshot) {
+        final authorName = snapshot.data ?? 'Unknown';
+        return ListTile(
+          title: Text(
+            post.postTitle,
+            style: const TextStyle(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                post.postContent,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
-            ),
-            const Text(
-              ' | ',
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
-            Text(
-              '${post.postCreatedTime.month}/${post.postCreatedTime.day}/${post.postCreatedTime.year}',
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
+              Row(
+                children: [
+                  Text(
+                    authorName,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const Text(
+                    ' | ',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  Text(
+                    '${post.postCreatedTime.month}/${post.postCreatedTime.day}/${post.postCreatedTime.year}',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
-      ]),
-      onTap: () {
-        Get.to(() => const PostedPage(), arguments: post);
+            ],
+          ),
+          onTap: () {
+            Get.to(() => const PostedPage(), arguments: post);
+          },
+        );
       },
     );
   }
 
-  static StreamBuilder<List<Post>> postStreamBuilder(
-      Stream<List<Post>>? function) {
+  StreamBuilder<List<Post>> postStreamBuilder(Stream<List<Post>>? function) {
     return StreamBuilder<List<Post>>(
       stream: function,
       builder: (context, snapshot) {
@@ -61,7 +70,7 @@ class PostListComponent {
           return ListView.builder(
             itemCount: posts.length,
             itemBuilder: (context, index) {
-              return buildPost(posts[index]);
+              return _buildPost(posts[index]);
             },
           );
         } else {

--- a/lib/pages/postpage/postspage.dart
+++ b/lib/pages/postpage/postspage.dart
@@ -13,6 +13,8 @@ class PostsPage extends StatefulWidget {
 }
 
 class _PostsPageState extends State<PostsPage> {
+  final _postListComponent = PostListComponent();
+
   @override
   void initState() {
     super.initState();
@@ -24,7 +26,8 @@ class _PostsPageState extends State<PostsPage> {
       appBar: AppBar(
         title: const Text('Posts'),
       ),
-      body: PostListComponent.postStreamBuilder(PostDatabaseService.getPosts()),
+      body:
+          _postListComponent.postStreamBuilder(PostDatabaseService.getPosts()),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           if (FirebaseAuth.instance.currentUser == null) {

--- a/lib/pages/profilepage/profilepage.dart
+++ b/lib/pages/profilepage/profilepage.dart
@@ -47,8 +47,6 @@ class _ProfilePageState extends State<ProfilePage> {
     _setUser();
   }
 
-  PostListComponent postListComponent = PostListComponent();
-
   Container profileBox(
       TextStyle textProfileUserStyle, TextStyle textProfileDescriptionStyle) {
     const double profileHeight = 200;
@@ -109,6 +107,7 @@ class _ProfilePageState extends State<ProfilePage> {
     const textProfileUserStyle =
         TextStyle(fontSize: 30, fontWeight: FontWeight.bold);
     var textProfileDescriptionStyle = const TextStyle(fontSize: 20);
+    final postListComponent = PostListComponent();
     return FutureBuilder<void>(
       future: _setUser(),
       builder: (context, snapshot) {
@@ -132,7 +131,7 @@ class _ProfilePageState extends State<ProfilePage> {
                 profileBox(textProfileUserStyle, textProfileDescriptionStyle),
                 const Text('Post List', style: textProfileUserStyle),
                 Expanded(
-                  child: PostListComponent.postStreamBuilder(
+                  child: postListComponent.postStreamBuilder(
                     PostDatabaseService.getPostsByUserId(_myUser.userId),
                   ),
                 ),

--- a/lib/repositories/user_database_service.dart
+++ b/lib/repositories/user_database_service.dart
@@ -43,6 +43,20 @@ class UserDatabaseService {
             .toList());
   }
 
+  /// Returns username of the user with the given userId
+  /// or 'Unknown' if the user does not exist
+  static Future<String> getUsernameById(String userId) {
+    if (userId.isEmpty) {
+      return Future.value('Unknown');
+    } else {
+      return FirebaseFirestore.instance
+          .collection('users')
+          .doc(userId)
+          .get()
+          .then((value) => value.data()?['userName'] ?? 'Unknown');
+    }
+  }
+
   static Future<void> updateUser(
       {required String userId,
       required String field,


### PR DESCRIPTION
근데 이게 맞는 건지는 모르겠음

일단 _buildPost가 매번 post를 빌드할 때마다, DB에서 authorName을 찾기 위해 uid를 통해서 읽기를 요청해야 함

이게 성능 문제도 있고 디비 사용량을 증가시키지 않을까 하는 우려가 있음

장점은 만약 유저가 프로필 편집을 통해서 이름을 바꾸었다 -> 그 정보가 이전 작성글에도 반영이 됨

그러나 유저가 프로필 편집으로 이름을 바꾸었어도, 예를 들어 nx006에서 nx007으로 바꾸었어도 이전 포스트의 저자는 nx006로 표시되는게 더 나은 방식일까 고민 중