### PR TITLE
변경 사항들 좀 많음

### DIFF
--- a/lib/database/community_database_service.dart
+++ b/lib/database/community_database_service.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:urbanlink_project/models/communities.dart';
+import 'package:urbanlink_project/services/auth.dart';
+
+class CommunityDatabaseService {
+  static final CollectionReference _communityCollection =
+      FirebaseFirestore.instance.collection('communities');
+
+  static Future<Community> createCommunity(Community community) async {
+    final docCommunity = _communityCollection.doc();
+    final json = {
+      'communityId': docCommunity.id,
+      'communityName': community.communityName,
+      'location': community.location,
+    };
+    try {
+      await docCommunity.set(json);
+      return community;
+    } catch (e) {
+      logger.e('Error: $e');
+    }
+
+    return Community(
+        communityId: docCommunity.id,
+        communityName: community.communityName,
+        location: community.location);
+  }
+
+  static Stream<List<Community>> getCommunities() {
+    try {
+      return _communityCollection.snapshots().map((snapshot) {
+        return snapshot.docs
+            .map((doc) => Community.fromSnapshot(doc))
+            .toList(growable: false);
+      });
+    } catch (e) {
+      logger.e('Error: $e');
+      return const Stream.empty();
+    }
+  }
+}

--- a/lib/database/community_database_service.dart
+++ b/lib/database/community_database_service.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
 import 'package:urbanlink_project/models/communities.dart';
 import 'package:urbanlink_project/services/auth.dart';
 
@@ -38,5 +37,31 @@ class CommunityDatabaseService {
       logger.e('Error: $e');
       return const Stream.empty();
     }
+  }
+
+  static Future<Community> getCommunityById(String communityId) async {
+    try {
+      final snapshot = await _communityCollection.doc(communityId).get();
+      if (snapshot.exists) {
+        return Community.fromSnapshot(snapshot);
+      }
+    } catch (e) {
+      logger.e('Error: $e');
+    }
+    return Community(communityId: '', communityName: '', location: '');
+  }
+
+  static Future<Community> getCommunityByLocation(String location) async {
+    try {
+      final snapshot = await _communityCollection
+          .where('location', isEqualTo: location)
+          .get();
+      if (snapshot.docs.isNotEmpty) {
+        return Community.fromSnapshot(snapshot.docs.first);
+      }
+    } catch (e) {
+      logger.e('Error: $e');
+    }
+    return Community(communityId: '', communityName: '', location: '');
   }
 }

--- a/lib/models/communities.dart
+++ b/lib/models/communities.dart
@@ -1,10 +1,11 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:urbanlink_project/models/posts.dart';
 
 /// Community model
 /// This model is used to store the community information
 class Community {
   final String communityId;
-  final String communityTitle;
+  final String communityName;
 
   /// location of the community
   final String location;
@@ -13,14 +14,14 @@ class Community {
 
   Community({
     required this.communityId,
-    required this.communityTitle,
+    required this.communityName,
     required this.location,
   });
 
   Map<String, dynamic> toJson() {
     return {
       'communityId': communityId,
-      'communityTitle': communityTitle,
+      'communityTitle': communityName,
       'locationId': location,
     };
   }
@@ -28,8 +29,8 @@ class Community {
   factory Community.fromJson(Map<String, dynamic> data) {
     return Community(
       communityId: data['communityId'] ?? 'Unknown',
-      communityTitle: data['communityTitle'] ?? 'Unknown',
-      location: data['locationId'] ?? '',
+      communityName: data['communityName'] ?? 'Unknown',
+      location: data['location'] ?? '',
     );
   }
 
@@ -39,12 +40,16 @@ class Community {
 
     return other is Community &&
         other.communityId == communityId &&
-        other.communityTitle == communityTitle &&
+        other.communityName == communityName &&
         other.location == location;
   }
 
   @override
   int get hashCode {
-    return communityId.hashCode ^ communityTitle.hashCode ^ location.hashCode;
+    return communityId.hashCode ^ communityName.hashCode ^ location.hashCode;
+  }
+
+  factory Community.fromSnapshot(DocumentSnapshot snapshot) {
+    return Community.fromJson(snapshot.data() as Map<String, dynamic>);
   }
 }

--- a/lib/pages/loginpage/login.dart
+++ b/lib/pages/loginpage/login.dart
@@ -201,9 +201,11 @@ class _LoginPageState extends State<LoginPage>
     _animationController.forward();
     _animationController.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
-        setState(() {
-          isDone = true;
-        });
+        if (mounted) {
+          setState(() {
+            isDone = true;
+          });
+        }
       } else if (status == AnimationStatus.dismissed) {
         _animationController.forward();
       }

--- a/lib/pages/mainpage/mainpage.dart
+++ b/lib/pages/mainpage/mainpage.dart
@@ -20,9 +20,11 @@ class _MainPageState extends State<MainPage> {
   ];
 
   void _onItemTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
+    if (mounted) {
+      setState(() {
+        _selectedIndex = index;
+      });
+    }
   }
 
   @override

--- a/lib/pages/mappage/mappage.dart
+++ b/lib/pages/mappage/mappage.dart
@@ -43,10 +43,11 @@ class _MapPageState extends State<MapPage> {
             ),
           ),
         );
-
-        setState(() {
-          _displayLocation = newCenter;
-        });
+        if (mounted) {
+          setState(() {
+            _displayLocation = newCenter;
+          });
+        }
       }
     } catch (e) {
       logger.e(e);
@@ -54,9 +55,11 @@ class _MapPageState extends State<MapPage> {
   }
 
   void _onMapCreated(GoogleMapController controller) {
-    setState(() {
-      _mapController = controller;
-    });
+    if (mounted) {
+      setState(() {
+        _mapController = controller;
+      });
+    }
   }
 
   addMarkers() async {
@@ -132,9 +135,11 @@ class _MapPageState extends State<MapPage> {
               width: MediaQuery.of(context).size.width,
               textController: textController,
               onSuffixTap: () {
-                setState(() {
-                  textController.clear();
-                });
+                if (mounted) {
+                  setState(() {
+                    textController.clear();
+                  });
+                }
               },
               onSubmitted: (String searchQuery) {
                 _searchLocation(searchQuery);

--- a/lib/pages/postpage/postedpage.dart
+++ b/lib/pages/postpage/postedpage.dart
@@ -2,13 +2,13 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:urbanlink_project/database/comment_database_service.dart';
-import 'package:urbanlink_project/database/storage_service.dart';
 import 'package:urbanlink_project/database/user_database_service.dart';
 import 'package:urbanlink_project/models/comments.dart';
 import 'package:urbanlink_project/models/posts.dart';
 import 'package:urbanlink_project/models/user.dart';
 import 'package:urbanlink_project/services/auth.dart';
 import 'package:urbanlink_project/widgets/comment_widget.dart';
+import 'package:urbanlink_project/widgets/image_list_widget.dart';
 import 'package:urbanlink_project/widgets/text_fieldwidget.dart';
 import 'package:urbanlink_project/widgets/like_button.dart';
 
@@ -21,39 +21,14 @@ class PostedPage extends StatefulWidget {
 
 class _PostedPageState extends State<PostedPage> {
   String _comment = '';
-  List<String> images = List.empty(growable: true);
-  bool isLoading = true;
-
-  void _fetchImages() async {
-    final Post post = Get.arguments;
-    var imgs = await StorageService.getImagesByPostId(post.postId);
-    setState(() {
-      images = imgs;
-      isLoading = false;
-    });
-  }
 
   @override
   void initState() {
     super.initState();
-
-    _fetchImages();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (isLoading) {
-      return Scaffold(
-        appBar: AppBar(
-          title: const Text('게시물'),
-          backgroundColor: const Color.fromARGB(250, 63, 186, 219),
-          shadowColor: Colors.grey,
-        ),
-        body: const Center(
-          child: CircularProgressIndicator(),
-        ),
-      );
-    }
     final Post post = Get.arguments;
     return Scaffold(
       backgroundColor: Colors.white24,
@@ -114,38 +89,7 @@ class _PostedPageState extends State<PostedPage> {
                         ),
                       ),
                       // image list
-                      SizedBox(
-                        height: 200,
-                        child: ListView.builder(
-                          scrollDirection: Axis.horizontal,
-                          itemCount: images.length,
-                          itemBuilder: (context, index) {
-                            return SizedBox(
-                              width: 200,
-                              height: 200,
-                              child: InkWell(
-                                onTap: () {
-                                  showDialog(
-                                    context: context,
-                                    builder: (BuildContext context) {
-                                      return Dialog(
-                                        child: Image.network(
-                                          images[index],
-                                          fit: BoxFit.contain,
-                                        ),
-                                      );
-                                    },
-                                  );
-                                },
-                                child: Image.network(
-                                  images[index],
-                                  fit: BoxFit.cover,
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
+                      ImageList(post: post),
                     ],
                   ),
                 ),
@@ -177,9 +121,11 @@ class _PostedPageState extends State<PostedPage> {
                         child: TextFieldWidget(
                           hintText: '댓글을 입력하세요',
                           onChanged: (value) {
-                            setState(() {
-                              _comment = value;
-                            });
+                            if (mounted) {
+                              setState(() {
+                                _comment = value;
+                              });
+                            }
                           },
                           label: '댓글',
                           text: _comment,
@@ -202,9 +148,11 @@ class _PostedPageState extends State<PostedPage> {
                               postId: post.postId,
                             );
                             await CommentDatabaseService.createComment(comment);
-                            setState(() {
-                              _comment = '';
-                            });
+                            if (mounted) {
+                              setState(() {
+                                _comment = '';
+                              });
+                            }
                           }
                         },
                       ),

--- a/lib/pages/postpage/postingpage.dart
+++ b/lib/pages/postpage/postingpage.dart
@@ -131,6 +131,7 @@ class _PostingPageState extends State<PostingPage> {
                         FirebaseAuth.instance.currentUser!.uid);
 
                     const communityId = '';
+
                     PostingService.postingByPosts(myUser!, _content, _headline,
                         communityId, locationId, images);
 

--- a/lib/pages/postpage/postingpage.dart
+++ b/lib/pages/postpage/postingpage.dart
@@ -24,6 +24,7 @@ class _PostingPageState extends State<PostingPage> {
   String _headline = '';
   String _content = '';
   String _location = '';
+  int maxImageCount = 10;
 
   @override
   void dispose() {
@@ -72,9 +73,17 @@ class _PostingPageState extends State<PostingPage> {
                             final pickedFile = await picker.pickImage(
                                 source: ImageSource.gallery);
                             if (pickedFile != null) {
-                              setState(() {
-                                images.add(File(pickedFile.path));
-                              });
+                              if (images.length >= maxImageCount) {
+                                Get.snackbar(
+                                    '사진은 $maxImageCount장까지만 등록할 수 있습니다.',
+                                    '사진을 삭제하고 다시 등록해주세요.');
+                                return;
+                              }
+                              if (mounted) {
+                                setState(() {
+                                  images.add(File(pickedFile.path));
+                                });
+                              }
                             }
                           } catch (e) {
                             logger.e(e);

--- a/lib/pages/postpage/postingpage.dart
+++ b/lib/pages/postpage/postingpage.dart
@@ -24,7 +24,7 @@ class _PostingPageState extends State<PostingPage> {
   List<File> images = List.empty(growable: true);
   String _headline = '';
   String _content = '';
-  String _location = '';
+  String _location = Get.arguments ?? '';
   int maxImageCount = 10;
 
   @override
@@ -117,6 +117,7 @@ class _PostingPageState extends State<PostingPage> {
                   onChanged: (value) {
                     _location = value;
                   },
+                  selectedLocation: _location,
                 ),
                 ElevatedButton(
                   onPressed: () async {

--- a/lib/pages/postpage/postingpage.dart
+++ b/lib/pages/postpage/postingpage.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:urbanlink_project/database/community_database_service.dart';
 import 'package:urbanlink_project/database/user_database_service.dart';
 import 'package:urbanlink_project/services/auth.dart';
 import 'package:urbanlink_project/services/posting_service.dart';
@@ -139,10 +140,12 @@ class _PostingPageState extends State<PostingPage> {
                     final myUser = await UserDatabaseService.getUserById(
                         FirebaseAuth.instance.currentUser!.uid);
 
-                    const communityId = '';
+                    final community =
+                        await CommunityDatabaseService.getCommunityByLocation(
+                            locationId);
 
                     PostingService.postingByPosts(myUser!, _content, _headline,
-                        communityId, locationId, images);
+                        community.communityId, locationId, images);
 
                     Get.back();
                   },

--- a/lib/pages/postpage/postspage.dart
+++ b/lib/pages/postpage/postspage.dart
@@ -53,7 +53,7 @@ class _PostsPageState extends State<PostsPage> {
             return;
           }
 
-          Get.to(const PostingPage());
+          Get.to(const PostingPage(), arguments: Get.arguments);
         },
         child: const Icon(Icons.post_add),
       ),

--- a/lib/pages/postpage/postspage.dart
+++ b/lib/pages/postpage/postspage.dart
@@ -3,12 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:urbanlink_project/database/post_database_service.dart';
 import 'package:urbanlink_project/widgets/location_drawer_widget.dart';
-import 'package:urbanlink_project/widgets/post_list_component.dart';
+import 'package:urbanlink_project/widgets/post_list_widget.dart';
 import 'package:urbanlink_project/pages/postpage/postingpage.dart';
 import 'package:urbanlink_project/models/posts.dart';
 
 class PostsPage extends StatefulWidget {
-  const PostsPage({super.key});
+  const PostsPage({super.key, this.postStream});
+
+  final Stream<List<Post>>? postStream;
 
   @override
   State<PostsPage> createState() => _PostsPageState();
@@ -17,7 +19,7 @@ class PostsPage extends StatefulWidget {
 class _PostsPageState extends State<PostsPage> {
   late Post post;
   List<String> posts = List.empty(growable: true);
-  String fakeLocation = Get.arguments ?? "location";
+  String location = Get.arguments ?? "location";
   @override
   void initState() {
     super.initState();
@@ -25,11 +27,9 @@ class _PostsPageState extends State<PostsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final postListComponent = PostListComponent();
     return Scaffold(
-      backgroundColor: Colors.white24,
       appBar: AppBar(
-        title: Text(fakeLocation),
+        title: Text(location),
         backgroundColor: const Color.fromARGB(250, 63, 186, 219),
         shadowColor: Colors.grey,
       ),
@@ -37,10 +37,9 @@ class _PostsPageState extends State<PostsPage> {
       body: Column(
         children: <Widget>[
           Expanded(
-            child: postListComponent.postStreamBuilder(
-              PostDatabaseService.getPosts(),
-            ),
-          ),
+              child: PostList(
+            postStream: widget.postStream ?? PostDatabaseService.getPosts(),
+          )),
         ],
       ),
       floatingActionButton: FloatingActionButton(

--- a/lib/pages/profilepage/profilepage.dart
+++ b/lib/pages/profilepage/profilepage.dart
@@ -3,7 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:urbanlink_project/database/user_database_service.dart';
 import 'package:urbanlink_project/widgets/menu_drawer_widget.dart';
-import 'package:urbanlink_project/widgets/post_list_component.dart';
+import 'package:urbanlink_project/widgets/post_list_widget.dart';
 import 'package:urbanlink_project/models/user.dart';
 import 'package:urbanlink_project/database/post_database_service.dart';
 
@@ -54,7 +54,7 @@ class _ProfilePageState extends State<ProfilePage> {
     const double profileHeight = 200;
     const double profileRound = 40;
     return Container(
-      margin: const EdgeInsets.fromLTRB(10, 20, 10, 0),
+        margin: const EdgeInsets.fromLTRB(10, 20, 10, 0),
         height: profileHeight,
         decoration: const BoxDecoration(
           boxShadow: [
@@ -102,7 +102,8 @@ class _ProfilePageState extends State<ProfilePage> {
                     //mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
                       Text(profileUser?.userName ?? 'Unknown',
-                          style: const TextStyle(fontSize: 30, fontWeight: FontWeight.w700)),
+                          style: const TextStyle(
+                              fontSize: 30, fontWeight: FontWeight.w700)),
                       Text(profileUser?.userExplanation ?? '',
                           style: textProfileDescriptionStyle),
                     ],
@@ -116,7 +117,6 @@ class _ProfilePageState extends State<ProfilePage> {
 
   @override
   Widget build(BuildContext context) {
-    final postListComponent = PostListComponent();
     return Scaffold(
       backgroundColor: Colors.white38,
       appBar: AppBar(
@@ -133,11 +133,12 @@ class _ProfilePageState extends State<ProfilePage> {
           Container(
             alignment: Alignment.centerLeft,
             padding: const EdgeInsets.fromLTRB(30, 20, 0, 10),
-            child: const Text('My Posts', style: TextStyle(fontSize: 20, fontWeight: FontWeight.normal)),
+            child: const Text('My Posts',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.normal)),
           ),
           Expanded(
-            child: postListComponent.postStreamBuilder(
-              PostDatabaseService.getPostsByUserId(
+            child: PostList(
+              postStream: PostDatabaseService.getPostsByUserId(
                   _myUser?.userId ?? 'Unknown'),
             ),
           ),

--- a/lib/widgets/image_list_widget.dart
+++ b/lib/widgets/image_list_widget.dart
@@ -18,6 +18,8 @@ class _ImageListState extends State<ImageList> {
   bool isLoading = true;
   late List<String> images;
 
+  static const double _imageHeight = 200;
+
   @override
   void initState() {
     super.initState();
@@ -40,13 +42,16 @@ class _ImageListState extends State<ImageList> {
   @override
   Widget build(BuildContext context) {
     if (isLoading) {
-      return const Center(
-        child: CircularProgressIndicator(),
+      return const SizedBox(
+        height: _imageHeight,
+        child: Center(
+          child: CircularProgressIndicator(),
+        ),
       );
     }
 
     return SizedBox(
-      height: 200,
+      height: _imageHeight,
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
         itemCount: images.length,

--- a/lib/widgets/image_list_widget.dart
+++ b/lib/widgets/image_list_widget.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:urbanlink_project/database/storage_service.dart';
+import 'package:urbanlink_project/models/posts.dart';
+
+class ImageList extends StatefulWidget {
+  const ImageList({
+    super.key,
+    required this.post,
+  });
+
+  final Post post;
+
+  @override
+  State<ImageList> createState() => _ImageListState();
+}
+
+class _ImageListState extends State<ImageList> {
+  bool isLoading = true;
+  late List<String> images;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchImages();
+  }
+
+  void _fetchImages() async {
+    if (mounted) {
+      var imgs = await StorageService.getImagesByPostId(widget.post.postId);
+
+      if (mounted) {
+        setState(() {
+          images = imgs;
+          isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
+
+    return SizedBox(
+      height: 200,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: images.length,
+        itemBuilder: (context, index) {
+          return SizedBox(
+            width: 200,
+            height: 200,
+            child: InkWell(
+              onTap: () {
+                showDialog(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return Dialog(
+                      child: Image.network(
+                        images[index],
+                        fit: BoxFit.contain,
+                      ),
+                    );
+                  },
+                );
+              },
+              child: Image.network(
+                images[index],
+                fit: BoxFit.cover,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/location_drawer_widget.dart
+++ b/lib/widgets/location_drawer_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:urbanlink_project/database/community_database_service.dart';
+import 'package:urbanlink_project/models/communities.dart';
 import 'package:urbanlink_project/pages/postpage/postspage.dart';
 
 class LocationDrawerWidget extends StatefulWidget {
@@ -12,46 +14,40 @@ class LocationDrawerWidget extends StatefulWidget {
 }
 
 class _LocationDrawerWidgetState extends State<LocationDrawerWidget> {
-  List<String> fakeLocations = [
-    "서울 마포구 창천동",
-    "서울 마포구 동교동",
-    "서울 서대문구 창천동",
-    "서울 마포구 서강동",
-    "서울 마포구 노고산동",
-    "서울 마포구 서교동",
-    "서울 마포구 상수동",
-    "서울 마포구 신수동",
-    "서울 마포구 구수동",
-    "서울 마포구 하중동",
-    "서울 마포구 신정동",
-    "서울 마포구 대흥동",
-    "서울 마포구 연남동",
-    "서울 마포구 현석동",
-    "서울 마포구 당인동",
-    "서울 마포구 용강동",
-    "서울 서대문구 대현동",
-    "서울 서대문구 신촌동",
-    "서울 마포구 염리동",
-    "서울 서대문구 대신동",
-    "서울 마포구 토정동",
-    "서울 마포구 망원제1동",
-    "서울 마포구 합정동",
-    "서울 마포구 성산제1동"
-  ];
+  List<String> locations = List.empty(growable: true);
 
   @override
   Widget build(BuildContext context) {
     return Drawer(
-        child: ListView.builder(
-      itemCount: fakeLocations.length,
-      itemBuilder: (c, i) => Card(
-        child: ListTile(
-          title: Text(fakeLocations[i]),
-          onTap: () {
-            Get.to(() => const PostsPage(), arguments: fakeLocations[i]);
-          },
-        ),
-      ),
+        child: StreamBuilder<List<Community>>(
+      stream: CommunityDatabaseService.getCommunities(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return const Center(
+            child: Text('Error'),
+          );
+        } else if (snapshot.hasData) {
+          final List<Community> communities = snapshot.data!;
+          return ListView.builder(
+            itemCount: communities.length,
+            itemBuilder: (context, index) {
+              return ListTile(
+                title: Text(communities[index].communityName),
+                onTap: () {
+                  Get.to(
+                    const PostsPage(),
+                    arguments: communities[index].communityName,
+                  );
+                },
+              );
+            },
+          );
+        } else {
+          return const Center(
+            child: CircularProgressIndicator(),
+          );
+        }
+      },
     ));
   }
 }

--- a/lib/widgets/location_drawer_widget.dart
+++ b/lib/widgets/location_drawer_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:urbanlink_project/database/community_database_service.dart';
+import 'package:urbanlink_project/database/post_database_service.dart';
 import 'package:urbanlink_project/models/communities.dart';
 import 'package:urbanlink_project/pages/postpage/postspage.dart';
 
@@ -35,7 +36,10 @@ class _LocationDrawerWidgetState extends State<LocationDrawerWidget> {
                 title: Text(communities[index].communityName),
                 onTap: () {
                   Get.to(
-                    const PostsPage(),
+                    () => PostsPage(
+                      postStream: PostDatabaseService.getPostsByCommunityId(
+                          communities[index].communityId),
+                    ),
                     arguments: communities[index].communityName,
                   );
                 },

--- a/lib/widgets/location_searchbar_widget.dart
+++ b/lib/widgets/location_searchbar_widget.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 
 class LocationSearchbar extends StatefulWidget {
   final ValueChanged<String> onChanged;
+  final String? selectedLocation;
 
-  const LocationSearchbar({Key? key, required this.onChanged})
+  const LocationSearchbar(
+      {Key? key, required this.onChanged, this.selectedLocation})
       : super(key: key);
 
   @override
@@ -13,6 +15,12 @@ class LocationSearchbar extends StatefulWidget {
 class _LocationSearchbarState extends State<LocationSearchbar> {
   List<String> searchResult = [];
   String _selectedLocation = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedLocation = widget.selectedLocation ?? '';
+  }
 
   List<String> fakeLocations = [
     "대한민국 서울 마포구 창전동",

--- a/lib/widgets/post_list_widget.dart
+++ b/lib/widgets/post_list_widget.dart
@@ -7,7 +7,16 @@ import 'package:urbanlink_project/database/user_database_service.dart';
 import 'package:urbanlink_project/services/auth.dart';
 import 'package:urbanlink_project/widgets/like_button.dart';
 
-class PostListComponent {
+class PostList extends StatefulWidget {
+  final Stream<List<Post>>? postStream;
+
+  const PostList({Key? key, this.postStream}) : super(key: key);
+
+  @override
+  State<PostList> createState() => _PostListState();
+}
+
+class _PostListState extends State<PostList> {
   Widget _buildPost(Post post) {
     return StreamBuilder<MyUser?>(
       stream: UserDatabaseService.getUserStreamById(post.postAuthorId),
@@ -93,9 +102,10 @@ class PostListComponent {
     );
   }
 
-  StreamBuilder<List<Post>> postStreamBuilder(Stream<List<Post>>? function) {
+  @override
+  Widget build(BuildContext context) {
     return StreamBuilder<List<Post>>(
-      stream: function,
+      stream: widget.postStream,
       builder: (context, snapshot) {
         if (snapshot.hasError) {
           logger.e(snapshot.error ?? 'Unknown error');
@@ -104,6 +114,11 @@ class PostListComponent {
           );
         } else if (snapshot.hasData) {
           final posts = snapshot.data!;
+          if (posts.isEmpty) {
+            return const Center(
+              child: Text('이 커뮤니티에는 포스트가 없습니다.\n글을 작성하여 이곳에 첫 포스트를 남겨보세요!'),
+            );
+          }
           return ListView.builder(
             itemCount: posts.length,
             itemBuilder: (context, index) {


### PR DESCRIPTION
# Feature changes
## Community list from database

Fetch data from database

<img width="300" alt="locationlist" src="https://user-images.githubusercontent.com/103521468/227804352-f972a77a-eae6-49b3-8d71-1e6017bbd114.png">

## 특정 커뮤니티에 맞는 게시물 보여줌

<img width="300" alt="image" src="https://user-images.githubusercontent.com/103521468/227804416-4471aa71-6514-467b-81f6-8f41db7cc603.png">

예를 들어서 서교동의 경우, 서교동 community가 태그된 게시물들만 보여줌

## default location when posting

![Simulator Screen Recording - iPhone 14 Pro Max - 2023-03-27 at 06 02 53](https://user-images.githubusercontent.com/103521468/227804520-e9e333d8-b2c5-42dd-a13b-ecd2ec73acaa.gif)


포스팅 페이지에 들어갈 때, 이제 그 이전 위치로 기본 위치가 선택됨

예를 들어 일반 페이지에서는 기본 위치가 없지만, 만약 서교동 커뮤니티 페이지에서 포스팅 페이지로 들어갈 경우 기본 위치가 서교동으로 설정됨

## Seperate post loading and image loading

포스팅을 불러올 때, image까지 모두 불러와야 posting을 볼 수 있었음

이제 posting과 image를 불러오는 것을 분리하여서, image가 로딩 중이여도 포스팅과 댓글 내용을 볼 수 있게 해놓음

![Simulator Screen Recording - iPhone 14 Pro Max - 2023-03-27 at 06 09 38](https://user-images.githubusercontent.com/103521468/227804787-4bec1941-cf5c-433c-8eb6-2d7aece45269.gif)

## 최대 이미지 갯수 제한

한 포스팅 당 최대 10개까지만 이미지를 담을 수 있도록 개수를 제한함

너무 많은 이미지를 담는 것을 방지하기 위함임

# Code changes

## Community Database Service

CRUD 로직을 추가함

## Convert postListComponent into Stateful widget

postListComponent가 기존에 그냥 클래스 형태로 돼있어서 사용하기가 어색했음

이제 위젯 형태로 바꿔놓음

추가적으로 PostListWidget으로 postStream을 받을 수 있음

이때 postStream에 따라 post를 불러오게 됨

## Seperate Image List Widget into Stateful widget

Note that `ImageList` and `ImageListBuilder` is different

- `ImageList`: For posted page
- `ImageList`: For posting page, this widget include delete icon button

```dart
Get.to(
  () => PostsPage(
    postStream: PostDatabaseService.getPostsByCommunityId(
        communities[index].communityId),
  ),
  arguments: communities[index].communityName,
```

이런 식으로 사용 가능

# bug fixes
## model name and database field name unmatched issue

커뮤니티 model field 와 firebase database의 필드 이름이 달라서, 계속 null or empty string이 리턴되고 있었음. 이에 맞추어서 수정함

***NOTE:** 현재 모델 필드명, database의 이름들이 다들 통일성이 없고, 서로 맞지 않는 경우도 있음. 이에 대한 리팩토링이 필요함*

## calling setState after dispose issue

Add checking mounted before calling setState

Since image loading is too long, and if user get the page out too early before images are fully loaded, it throws error after images are loaded.

이미지를 다운받는데 오래 걸리고, 유저가 이미지 받기도 전에 먼저 페이지가 나오면, 그 페이지에 `dispose`가 호출되는데, 호출된 이후에 mounted를 체크하지 않고 setState를 호출하니깐 에러가 발생함

그래서 setState 전에 mounted를 검사하게끔 했고, 만약 **data fetching이 조금이라도 오래 걸리는 곳에서는 mounted checking을 꼭 해놓아야 함**

```dart
  var imgs = await StorageService.getImagesByPostId(widget.post.postId);
  if (mounted) { // mounted checking
    setState(() {
      images = imgs;
      isLoading = false;
    });
  }
```

이런 식으로
*(`StorageService.getImagesByPostId(widget.post.postId)`가 오래 걸리면서, 유저가 `imgs`가 로드되기 전에 나간 상황)*


